### PR TITLE
Documentation - Add official documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,8 +2,12 @@
 
 This application contains an example implementation of creating Jetpack compose using the JW Player SDK for Android.
 
-#### Usage instructions:
+## Usage instructions
 
--	Open the `MainActivity` and replace `YOUR_LICENSE_KEY` with your license key
+- Open the `MainActivity` and replace `YOUR_LICENSE_KEY` with your license key
 
 The demo application should now build and run. For more information on how to use our SDK refer to our [developer guide](https://developer.jwplayer.com/jwplayer/docs/android-get-started)
+
+## Documentation
+
+For more detailed information, refer to the [JWPlayer Official Documentation](implementation/jwp-official-documentation.md).

--- a/docs/implementation/jwp-official-documentation.md
+++ b/docs/implementation/jwp-official-documentation.md
@@ -1,0 +1,11 @@
+# JWPlayer Official Documentation
+
+Bellow you will find some helpful links from the official documentation for the JWPlayer:
+
+- [JWPlayer official documentation][official-documentation]
+- [Documentation for the Android JWPlayer SDK][android-sdk]
+- [Code samples][code-samples]
+
+[android-sdk]: https://docs.jwplayer.com/players/docs/android-add-the-sdk
+[code-samples]: https://github.com/jwplayer/jwplayer-android-best-practice-apps
+[official-documentation]: https://docs.jwplayer.com/players/docs/android-add-the-sdk


### PR DESCRIPTION
- Move README contents to `docs/README.md`.
- Add `docs/implementation/jwp-official-documentation.md` with links to the official documentation.

